### PR TITLE
Update twitter_widget.class.php to work with WP 4.3

### DIFF
--- a/twitter_widget.class.php
+++ b/twitter_widget.class.php
@@ -126,7 +126,7 @@
 		if(!is_admin())
 			add_action( 'wp_enqueue_scripts', array( &$this, 'wpltf_register_styles' ) );
 		$widget_data = array('classname' => 'wptt_TwitterTweets', 'description' => 'A simple widget which lets you add your latest tweets in just a few clicks on your website.' );
-		$this->WP_Widget('wptt_TwitterTweets', 'WP Twitter Feeds', $widget_data);
+		parent::__construct('wptt_TwitterTweets', 'WP Twitter Feeds', $widget_data);
 	}
 	
 	function wpltf_register_styles() {


### PR DESCRIPTION
Resolving issue with the latest update from WP shown as:

```
NOTICE: The called constructor method for WP_Widget is DEPRECATED since
version 4.3.0! Use__construct()
```
